### PR TITLE
REST GIS - use djangorestframework-gis

### DIFF
--- a/actionmaps_backend/settings.py
+++ b/actionmaps_backend/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'rest_framework_gis',
 
     'maps',
 )

--- a/maps/v1_serializers.py
+++ b/maps/v1_serializers.py
@@ -1,36 +1,19 @@
 # -*- coding: utf-8 -*-
 # Serializers define the API representation.
 
-from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from maps.models import Map, Feature
-from maps.utils import parse_bbox_string, get_bbox_string
 
 
-class MapSerializer(serializers.ModelSerializer):
+class MapSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Map
+        geo_field = 'bbox'
         fields = ('name', 'bbox', 'public', 'editable')
 
-    def create(self, validated_data):
-        validated_data['bbox'] = parse_bbox_string(validated_data['bbox'])
-        return super(MapSerializer, self).create(validated_data)
 
-    def update(self, instance, validated_data):
-        validated_data['bbox'] = parse_bbox_string(validated_data['bbox'])
-        return super(MapSerializer, self).update(instance, validated_data)
-
-    def to_representation(self, instance):
-        response = super(MapSerializer, self).to_representation(instance)
-        response['bbox'] = get_bbox_string(instance.bbox)
-        return response
-
-
-class FeatureSerializer(serializers.ModelSerializer):
+class FeatureSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Feature
+        geo_field = 'geo'
         fields = ('geo', 'map', 'id')
-
-    def to_representation(self, instance):
-        response = super(FeatureSerializer, self).to_representation(instance)
-        response['geo'] = instance.geo.json
-        return response

--- a/maps/v1_views.py
+++ b/maps/v1_views.py
@@ -7,7 +7,7 @@ from maps.v1_serializers import MapSerializer, FeatureSerializer
 
 
 class MapViewSet(viewsets.ModelViewSet):
-    queryset = Map.objects.public()
+    queryset = Map.objects.all()
     serializer_class = MapSerializer
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django
 djangorestframework
-# django-websocket-redis
+djangorestframework-gis


### PR DESCRIPTION
rely on djangorestframework-gis to translate GeoDjango objects to GeoJson